### PR TITLE
Add quality parameter to Hap exporter plugin

### DIFF
--- a/source/premiere_CC2018/codec/codec.cpp
+++ b/source/premiere_CC2018/codec/codec.cpp
@@ -15,7 +15,8 @@ Codec::Codec(
     CodecSubType subType,
     const FrameDef& frameDef,
     HapChunkCounts chunkCounts,
-    const std::vector<unsigned int>& textureFormats)
+    const std::vector<unsigned int>& textureFormats,
+    SquishEncoderQuality textureQuality)
     : subType_(subType),
       frameDef_(frameDef),
       count_((int)textureFormats.size()),
@@ -25,7 +26,7 @@ Codec::Codec(
     for (size_t i = 0; i < count_; ++i)
     {
         textureFormats_[i] = textureFormats[i];
-        converters_[i] = TextureConverter::create(frameDef, textureFormats[i]);
+        converters_[i] = TextureConverter::create(frameDef, textureFormats[i], textureQuality);
         sizes_[i] = (unsigned long)converters_[i]->size();
     }
 }
@@ -36,7 +37,9 @@ Codec::~Codec()
 }
 
 
-std::unique_ptr<Codec> Codec::create(CodecSubType codecType, const FrameDef& frameDef, HapChunkCounts chunkCounts)
+std::unique_ptr<Codec> Codec::create(CodecSubType codecType, const FrameDef& frameDef,
+                                    HapChunkCounts chunkCounts,
+                                    SquishEncoderQuality textureQuality)
 {
     std::vector<unsigned int> textureFormats;
 
@@ -62,7 +65,7 @@ std::unique_ptr<Codec> Codec::create(CodecSubType codecType, const FrameDef& fra
     else
         throw std::runtime_error("unknown codec");
 
-    return std::make_unique<Codec>(codecType, frameDef, chunkCounts, textureFormats);
+    return std::make_unique<Codec>(codecType, frameDef, chunkCounts, textureFormats, textureQuality);
 }
 
 std::string Codec::getSubTypeAsString() const

--- a/source/premiere_CC2018/codec/codec.hpp
+++ b/source/premiere_CC2018/codec/codec.hpp
@@ -47,10 +47,13 @@ public:
         CodecSubType subType,
 		const FrameDef& frameDef,
         HapChunkCounts chunkCounts,
-		const std::vector<unsigned int>& textureFormats);
+		const std::vector<unsigned int>& textureFormats,
+		SquishEncoderQuality textureQuality);
 	~Codec();
 
-	static std::unique_ptr<Codec> create(CodecSubType codecType, const FrameDef& frameDef, HapChunkCounts chunkCounts);
+	static std::unique_ptr<Codec> create(CodecSubType codecType, const FrameDef& frameDef,
+										HapChunkCounts chunkCounts,
+										SquishEncoderQuality textureQuality);
 
     CodecSubType subType() const { return subType_; }
 	std::string getSubTypeAsString() const;

--- a/source/premiere_CC2018/codec/texture_converter.cpp
+++ b/source/premiere_CC2018/codec/texture_converter.cpp
@@ -97,14 +97,28 @@ size_t TextureConverter::size() const
 }
 
 
-std::unique_ptr<TextureConverter> TextureConverter::create(const FrameDef& frameDef, unsigned int destFormat)
+std::unique_ptr<TextureConverter> TextureConverter::create(const FrameDef& frameDef, unsigned int destFormat, SquishEncoderQuality quality)
 {
+	int flag_quality;
+	switch (quality)
+	{
+	case kSquishEncoderFastQuality:
+		flag_quality = squish::kColourRangeFit;
+		break;
+	case kSquishEncoderBestQuality:
+		flag_quality = squish::kColourIterativeClusterFit;
+		break;
+	default:
+		flag_quality = squish::kColourClusterFit;
+		break;
+	}
+
 	switch (destFormat)
 	{
 	case HapTextureFormat_RGB_DXT1:
-		return std::make_unique<SquishTextureConverter>(frameDef, squish::kDxt1);
+		return std::make_unique<SquishTextureConverter>(frameDef, squish::kDxt1 | flag_quality);
 	case HapTextureFormat_RGBA_DXT5:
-		return std::make_unique<SquishTextureConverter>(frameDef, squish::kDxt5);
+		return std::make_unique<SquishTextureConverter>(frameDef, squish::kDxt5 | flag_quality);
 	case HapTextureFormat_YCoCg_DXT5:
 		return std::make_unique<TextureConverterToYCoCg_Dxt5>(frameDef);
 	case HapTextureFormat_A_RGTC1:

--- a/source/premiere_CC2018/codec/texture_converter.hpp
+++ b/source/premiere_CC2018/codec/texture_converter.hpp
@@ -9,6 +9,12 @@
 
 typedef std::array<char, 4> CodecSubType;
 
+enum SquishEncoderQuality {
+    kSquishEncoderFastQuality = 0,
+    kSquishEncoderNormalQuality = 1,
+    kSquishEncoderBestQuality = 2
+};
+
 // Details of frame
 
 struct FrameDef
@@ -31,7 +37,7 @@ public:
 	{}
 	virtual ~TextureConverter();
 
-	static std::unique_ptr<TextureConverter> create(const FrameDef& frameDef, unsigned int destFormat);
+	static std::unique_ptr<TextureConverter> create(const FrameDef& frameDef, unsigned int destFormat, SquishEncoderQuality quality);
 
 	const FrameDef& frameDef() const { return frameDef_; }
 

--- a/source/premiere_CC2018/configure.hpp
+++ b/source/premiere_CC2018/configure.hpp
@@ -37,3 +37,7 @@
 #define STR_HAP_SUBCODEC_3              L"Hap Q Alpha"
 #define STR_HAP_SUBCODEC_4              L"Hap Alpha-Only"
 #define STR_HAP_CHUNKING                L"Chunk count"
+#define STR_HAP_QUALITY                 L"Quality"
+#define STR_HAP_QUALITY_0               L"Fast"
+#define STR_HAP_QUALITY_1               L"Normal"
+#define STR_HAP_QUALITY_2               L"Best"

--- a/source/premiere_CC2018/main.cpp
+++ b/source/premiere_CC2018/main.cpp
@@ -301,13 +301,14 @@ static void renderAndWriteAllVideo(exDoExportRec* exportInfoP, prMALError& error
 {
 	const csSDK_uint32 exID = exportInfoP->exporterPluginID;
 	ExportSettings* settings = reinterpret_cast<ExportSettings*>(exportInfoP->privateData);
-	exParamValues ticksPerFrame, width, height, hapSubcodec, chunkCount;
+	exParamValues ticksPerFrame, width, height, hapSubcodec, hapQuality, chunkCount;
 	PrTime ticksPerSecond;
 
 	settings->exportParamSuite->GetParamValue(exID, 0, ADBEVideoFPS, &ticksPerFrame);
 	settings->exportParamSuite->GetParamValue(exID, 0, ADBEVideoWidth, &width);
 	settings->exportParamSuite->GetParamValue(exID, 0, ADBEVideoHeight, &height);
     settings->exportParamSuite->GetParamValue(exID, 0, ADBEVideoCodec, &hapSubcodec);
+    settings->exportParamSuite->GetParamValue(exID, 0, ADBEVideoQuality, &hapQuality);
     settings->exportParamSuite->GetParamValue(exID, 0, HAPChunkCount, &chunkCount);
     settings->timeSuite->GetTicksPerSecond(&ticksPerSecond);
     const int64_t frameRateNumerator = ticksPerSecond;
@@ -322,7 +323,8 @@ static void renderAndWriteAllVideo(exDoExportRec* exportInfoP, prMALError& error
 	std::unique_ptr<Codec> codec = std::unique_ptr<Codec>(
         Codec::create(reinterpret_cast<CodecSubType&>(hapSubcodec.value.intValue),
 					  FrameDef(width.value.intValue, height.value.intValue),
-                      chunkCounts));
+                      chunkCounts,
+                      static_cast<SquishEncoderQuality>(hapQuality.value.intValue)));
 
     //--- this error flag may be overwritten fairly deeply in callbacks so original error may be
     //--- passed up to Adobe

--- a/source/premiere_CC2018/premiereParams.cpp
+++ b/source/premiere_CC2018/premiereParams.cpp
@@ -93,6 +93,19 @@ prMALError generateDefaultParams(exportStdParms *stdParms, exGenerateDefaultPara
 		hapSubcodecParam.paramValues = hapSubcodecValues;
 		exportParamSuite->AddParam(exporterPluginID, mgroupIndex, ADBEBasicVideoGroup, &hapSubcodecParam);
 
+        exNewParamInfo hapQualityParam;
+        exParamValues hapQualityValues;
+        safeStrCpy(hapQualityParam.identifier, 256, ADBEVideoQuality);
+        hapQualityParam.paramType = exParamType_int;
+        hapQualityParam.flags = exParamFlag_none;
+        hapQualityValues.rangeMin.intValue = 0;
+        hapQualityValues.rangeMax.intValue = 2;
+        hapQualityValues.value.intValue = 1;
+        hapQualityValues.disabled = kPrFalse;
+        hapQualityValues.hidden = kPrFalse;
+        hapQualityParam.paramValues = hapQualityValues;
+        exportParamSuite->AddParam(exporterPluginID, mgroupIndex, ADBEBasicVideoGroup, &hapQualityParam);
+
 		exNewParamInfo frameRateParam;
         exParamValues frameRateValues;
         safeStrCpy(frameRateParam.identifier, 256, ADBEVideoFPS);
@@ -119,7 +132,7 @@ prMALError generateDefaultParams(exportStdParms *stdParms, exGenerateDefaultPara
         chunkCountParam.paramValues = chunkCountValues;
         exportParamSuite->AddParam(exporterPluginID, mgroupIndex, HAPSpecificCodecGroup, &chunkCountParam);
 
-        exportParamSuite->SetParamsVersion(exporterPluginID, 4);
+        exportParamSuite->SetParamsVersion(exporterPluginID, 5);
     }
 
     return result;
@@ -132,6 +145,8 @@ prMALError postProcessParams(exportStdParms *stdParmsP, exPostProcessParamsRec *
     PrTime ticksPerSecond = 0;
 	exOneParamValueRec tempHapSubcodec;
 	CodecSubType HAPsubcodecs[] = { kHapCodecSubType, kHapAlphaCodecSubType, kHapYCoCgCodecSubType, kHapYCoCgACodecSubType, kHapAOnlyCodecSubType };
+    exOneParamValueRec tempHapQuality;
+    SquishEncoderQuality HAPquality[] = { kSquishEncoderFastQuality, kSquishEncoderNormalQuality, kSquishEncoderBestQuality };
     exOneParamValueRec tempFrameRate;
     PrTime frameRates[] = { 10, 15, 23, 24, 25, 29, 30, 50, 59, 60 };
     PrTime frameRateNumDens[][2] = { { 10, 1 }, { 15, 1 }, { 24000, 1001 }, { 24, 1 }, { 25, 1 }, { 30000, 1001 }, { 30, 1 }, { 50, 1 }, { 60000, 1001 }, { 60, 1 } };
@@ -139,6 +154,7 @@ prMALError postProcessParams(exportStdParms *stdParmsP, exPostProcessParamsRec *
     prUTF16Char tempString[256];
     const wchar_t* frameRateStrings[] = { STR_FRAME_RATE_10, STR_FRAME_RATE_15, STR_FRAME_RATE_23976, STR_FRAME_RATE_24, STR_FRAME_RATE_25, STR_FRAME_RATE_2997, STR_FRAME_RATE_30, STR_FRAME_RATE_50, STR_FRAME_RATE_5994, STR_FRAME_RATE_60 };
 	const wchar_t *hapSubcodecStrings[] = { STR_HAP_SUBCODEC_0, STR_HAP_SUBCODEC_1, STR_HAP_SUBCODEC_2, STR_HAP_SUBCODEC_3, STR_HAP_SUBCODEC_4 };
+    const wchar_t *hapQualityStrings[] = { STR_HAP_QUALITY_0, STR_HAP_QUALITY_1, STR_HAP_QUALITY_2 };
 
 	settings->timeSuite->GetTicksPerSecond(&ticksPerSecond);
     for (csSDK_int32 i = 0; i < sizeof(frameRates) / sizeof(PrTime); i++)
@@ -169,6 +185,16 @@ prMALError postProcessParams(exportStdParms *stdParmsP, exPostProcessParamsRec *
         tempHapSubcodec.intValue = reinterpret_cast<int32_t &>(HAPsubcodecs[i][0]);
         copyConvertStringLiteralIntoUTF16(hapSubcodecStrings[i], tempString);
         settings->exportParamSuite->AddConstrainedValuePair(exID, 0, ADBEVideoCodec, &tempHapSubcodec, tempString);
+    }
+
+    copyConvertStringLiteralIntoUTF16(STR_HAP_QUALITY, tempString);
+    settings->exportParamSuite->SetParamName(exID, 0, ADBEVideoQuality, tempString);
+    settings->exportParamSuite->ClearConstrainedValues(exID, 0, ADBEVideoQuality);
+    for (csSDK_int32 i = 0; i < sizeof(HAPquality) / sizeof(HAPquality[0]); i++)
+    {
+        tempHapQuality.intValue = HAPquality[i];
+        copyConvertStringLiteralIntoUTF16(hapQualityStrings[i], tempString);
+        settings->exportParamSuite->AddConstrainedValuePair(exID, 0, ADBEVideoQuality, &tempHapQuality, tempString);
     }
 
     copyConvertStringLiteralIntoUTF16(STR_FRAME_RATE, tempString);


### PR DESCRIPTION
Hap Quality parameter options:
Fast - RangeFit
Normal - Default ClusterFit
Best - Interactive ClusterFit

Changes affects only Hap and Hap Alpha subcodecs (Fast mimic 50% QTHap codec).
